### PR TITLE
Fix error when displaying preferences / webhook page

### DIFF
--- a/main/plugins/org.talend.core.ui/plugin.xml
+++ b/main/plugins/org.talend.core.ui/plugin.xml
@@ -65,7 +65,7 @@
     />
     <page
       category="org.talend.core.prefs"
-      class="org.talend.core.ui.preference.collector.WebhookPreferencePage"
+      class="org.talend.core.ui.preference.webhook.WebhookPreferencePage"
       id="org.talend.core.prefs.datacollector"
       name="%Webhook"
     />


### PR DESCRIPTION
Fix error Unable to create the selected preference page. org.talend.c…ore.ui.preference.collector.WebhookPreferencePage cannot be found by org.talend.core.ui_8.8.8.20241115_0853